### PR TITLE
feat: Add support for ignoring movies already seen in showtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-.wl
+.wl_*
+.sm_*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To make the program run, you have to get a [TMDB](https://www.themoviedb.org/) k
 ## Usage
 ```
 usage: cine.py [-h] [-a ACCOUNT] [-d DAYS] [-p PERIOD] [-c CITIES [CITIES ...]] [-l LIMIT] [-t THEATER [THEATER ...]]
+               [-i] [-f] [-m]
 
 Display showtimes of Cinevillepass
 
@@ -23,7 +24,20 @@ options:
                         Limit of showtimes to fetch
   -t THEATER [THEATER ...], --theater THEATER [THEATER ...]
                         Theater to query
+  -i, --ignore          Ignore the movies that you have already seen
+  -f, --full            Display full showtimes
+  -m, --minimal         Minimal Display (for fuzzy finding for example)
 ```
+### Examples
+- Find all the unseen movies of the week in Namur:
+```bash
+python3 cine.py -a username -f -c namur -i
+```
+- Fuzzy find a movie in the showtimes of the week:
+```bash
+python3 cine.py -m -f | fzf
+```
+
 
 ### Dependencies
 All the dependencies are shown in the file `requirement.txt`.

--- a/cine.py
+++ b/cine.py
@@ -1,13 +1,14 @@
 #!/usr/bin/python3
 
 from cine.api.letterboxd.WatchList import WatchList
+from cine.api.letterboxd.SeenMovies import SeenMovies
 from cine.api.Showtimes import Showtimes
 from datetime import datetime, timedelta
 from cine.api.Show import Show
 from cine.api.Theaters import Theaters
 from math import log
 import argparse
-from cine.display import display_showtimes, display_showtimes_with_watchlist
+from cine.display import display_showtimes, display_showtimes_with_account
 
 
 
@@ -19,17 +20,18 @@ def main(args) -> int:
     next_day = current_date + timedelta(days=args.period)
     next_day = next_day.replace(hour=0, minute=0, second=0, microsecond=0)
     f_theaters = []
-    theaters = Theaters(args.cities)
+    theaters = Theaters(args.cities, minimal=args.minimal)
     if args.theater is not None:
         for theater in theaters.getTheaters():
             if theater.getSlug() in args.theater:
                 f_theaters.append(theater)
-    showtimes = Showtimes(args.cities, dateBegin=current_date, dateEnd=next_day, theaters=f_theaters)
+    showtimes = Showtimes(args.cities, dateBegin=current_date, dateEnd=next_day, theaters=f_theaters, minimal=args.minimal)
     if args.account is not None:
-        watchlist = WatchList(args.account)
-        display_showtimes_with_watchlist(showtimes, watchlist, theaters)
+        watchlist = WatchList(args.account, minimal=args.minimal)
+        seen_movies = SeenMovies(args.account, minimal=args.minimal)
+        display_showtimes_with_account(showtimes, watchlist, theaters, seen_movies, args.limit, args.ignore, args.minimal)
     else:
-        display_showtimes(showtimes, theaters)
+        display_showtimes(showtimes, theaters, args.limit, args.minimal)
     return 0
 
 if __name__ == "__main__":
@@ -41,5 +43,10 @@ if __name__ == "__main__":
     parser.add_argument('-c', '--cities', nargs='+', help="Cities to query", default=[], required=False)
     parser.add_argument("-l", "--limit", help="Limit of showtimes to fetch", type=int, required=False)
     parser.add_argument("-t", "--theater", help="Theater to query", nargs='+', required=False)
+    parser.add_argument("-i", "--ignore", help="Ignore the movies that you have already seen", action="store_true", required=False)
+    parser.add_argument("-f", "--full", help="Display full showtimes", action="store_true", required=False)
+    parser.add_argument("-m", "--minimal", help="Minimal Display (for fuzzy finding for example)", action="store_true", required=False)
     args = parser.parse_args()
+    if args.full:
+        args.period = 8
     sys.exit(main(args))

--- a/cine/api/Showtimes.py
+++ b/cine/api/Showtimes.py
@@ -6,17 +6,18 @@ from .k_cities import k_cities
 from .Theater import Theater
 
 class Showtimes:
-    def __init__(self, cities: list[str], dateBegin: datetime, dateEnd: datetime, theaters: list[Theater], limit=0) -> None:
+    def __init__(self, cities: list[str], dateBegin: datetime, dateEnd: datetime, theaters: list[Theater], limit=0, minimal=False) -> None:
         self._url = "https://cinevillepass.be/api/graphql"
         self._cities = cities
         self._dateBegin = dateBegin
         self._dateEnd = dateEnd
         self._limit = limit
         self._theaters = theaters
+        self._minimal = minimal
         self._showtimes = self.fetchShowtimes()
 
     def fetchShowtimes(self) -> list[Show]:
-        print(f"🚀 Fetching showtimes from {self._dateBegin} to {self._dateEnd}")
+        print(f"🚀 Fetching showtimes from {self._dateBegin} to {self._dateEnd}") if not self._minimal else None
         r = requests.post(url = self._url, json = {"operationName": "showtimes", "query": "query showtimes(  $filters: ShowtimesFilters  $collections: [CollectionFilter!]  $page: CursorPagination  $sort: ShowtimesSort  $locale: String) {  showtimes(    filters: $filters    collections: $collections    page: $page    sort: $sort    locale: $locale  ) {    totalCount    data {      startDate      endDate      film {        id        slug        title        releaseYear      }      theater {        id      }    }    count  }}", 
                                                                                 "variables" : {
                                                                                     "collections": [{"collectionGroupId": "cities", "collectionId": city, "id": str(k_cities[city])} for city in self._cities],

--- a/cine/api/Theaters.py
+++ b/cine/api/Theaters.py
@@ -3,13 +3,14 @@ from .k_cities import k_cities
 from .Theater import Theater
 
 class Theaters:
-    def __init__(self, cities: list[str]) -> None:
+    def __init__(self, cities: list[str], minimal=False) -> None:
         self._url = "https://cinevillepass.be/api/graphql"
         self._cities = cities
+        self._minimal = minimal
         self._theaters = self.fetchTheaters()
 
     def fetchTheaters(self) -> list[Theater]:
-        print(f"🚀 Fetching theaters")
+        print(f"🚀 Fetching theaters") if not self._minimal else None
         r = requests.post(url = self._url, json = {"operationName": "theaters", "query": "query theaters($filters: TheatersFilters, $collections: [CollectionFilter!], $page: CursorPagination, $sort: TheatersSort, $locale: String) {  theaters(    filters: $filters    collections: $collections    page: $page    sort: $sort    locale: $locale  ) {    data {      ...theater      __typename    }    ...pageInfo    __typename  }}fragment address on Address {  street  houseNumber  postalCode  city  country  __typename}fragment asset on Asset {  url  mime  alternativeText  __typename}fragment theater on Theater {  id  slug  name  address {    ...address    __typename  }  cover {    ...asset    __typename  }  website  shortDescription  intro  description  ticketInfo  __typename}fragment pageInfo on Response {  count  totalCount  previous  next  __typename}", 
                                                     "variables" : {
                                                         "collections": [{"collectionGroupId": "cities", "collectionId": city, "id": str(k_cities[city])} for city in self._cities]

--- a/cine/api/letterboxd/SeenMovies.py
+++ b/cine/api/letterboxd/SeenMovies.py
@@ -1,0 +1,78 @@
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+from .Movie import Movie
+import requests
+import os
+
+seen_movies_pre = ".sm_"
+
+class SeenMovies:
+    def __init__(self, account_name, minimal=False) -> None:
+        self._account_name = account_name
+        self._minimal = minimal
+        self._seen_movies = self.fetchSeenMovies()
+
+    def fetchSeenMovies(self) -> list[list[str]]:
+        self._seen_movies = []
+        seen_movies_url = f"https://letterboxd.com/{self._account_name}/films/"
+        response = requests.get(seen_movies_url)
+        soup = BeautifulSoup(response.text, "html.parser")
+        # To find the total number of movies, you have that information in this <a href="/korzie/films/" class="tooltip" data-original-title="317&nbsp;films">Watched</a>
+        movies = soup.find("a", attrs={"class": "tooltip", "href": f"/{self._account_name}/films/"})
+        if len(movies) > 0:
+            total_movies = int(movies.get("title").split()[0])
+            
+        self._cached_seen_movies = []
+        self.loadFromFile(seen_movies_pre + self._account_name, self._cached_seen_movies)
+        
+        number_of_pages = int(soup.find_all("li", attrs={"class": "paginate-page"})[-1].text)
+        with tqdm(total=total_movies, desc=f"🚀 Fetching seen movies for {self._account_name}", disable=(True if self._minimal else False)) as pbar:
+            for page in range(1, number_of_pages + 1):
+                if page > 1:
+                    response = requests.get(f"{seen_movies_url}page/{page}/")
+                    soup = BeautifulSoup(response.text, "html.parser")
+                
+                ul = soup.find("ul", attrs={"class": "poster-list"})
+                li = ul.find_all("li")
+                for movie in li:
+                    found_in_cache = False
+                    for sm_movie in self._cached_seen_movies:
+                        if sm_movie.getTitle() == movie.div.attrs["data-film-slug"]:
+                            found_in_cache = True
+                            self._seen_movies.append(sm_movie)
+                            pbar.update(1)
+                            break
+                    if not found_in_cache:
+                        self._seen_movies.append(Movie().loadFromInternet(movie))
+                        pbar.update(1)
+                    
+        self.saveSeenMovies(seen_movies_pre + self._account_name)
+        return self._seen_movies
+    
+    def loadFromFile(self, filename: str, list) -> None:
+        if os.path.isfile(filename):
+            with open(filename, "r") as file:
+                for line in file:
+                    movie = line.strip()
+                    movie_infos = movie.split(",")
+                    list.append(Movie().set(movie_infos[0], movie_infos[1]))
+
+    def getSeenMoviesSize(self) -> int:
+        return len(self._seen_movies) - 1
+    
+    def saveSeenMovies(self, filename: str) -> None:
+        with open(filename, "w") as file:
+            for movie in self._seen_movies:
+                file.write(f"{movie.getTitle()},{movie.getTMDBID()}\n")
+    
+    def getSeenMovies(self) -> list[Movie]:
+        return self._seen_movies
+    
+    def getSeenMovie(self, index: int) -> Movie:
+        return self._seen_movies[index]
+    
+    def getSeenMovieByTMDBID(self, tmdb_id: str) -> Movie:
+        for movie in self._seen_movies:
+            if movie.getTMDBID() == tmdb_id:
+                return movie
+        return None

--- a/cine/display.py
+++ b/cine/display.py
@@ -4,10 +4,19 @@ import cine.colors as colors
 def href(url: str, text: str) -> str:
     return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
 
-def println(found_in_watchlist: bool, counter: int, showtime: Show, title_width: int, theater_width: int, date_width: int, length, theaters) -> bool:
+def println(found_in_watchlist: bool, seen: bool, counter: int, showtime: Show, title_width: int, theater_width: int, date_width: int, length, theaters, minimal: bool) -> bool:
     line = "⭐" if found_in_watchlist else "  "
     counter_string = f"({counter:0{len(str(length))}d}) "
-    title = (colors.YELLOW if found_in_watchlist else "") + (href(f"https://www.letterboxd.com/tmdb/{showtime.getTMDBID()}", showtime.getTitle()) if (showtime.getTMDBID() != None) else showtime.getTitle()) + " " * (title_width - len(showtime.getTitle())) + colors.RESET
+    text_color = ""
+    if found_in_watchlist and not minimal:
+        text_color = colors.YELLOW
+    elif seen and not minimal:
+        text_color = colors.DARK_GRAY
+
+    if minimal:
+        title = showtime.getTitle() + " " * (title_width - len(showtime.getTitle()))
+    else:
+        title = (text_color) + (href(f"https://www.letterboxd.com/tmdb/{showtime.getTMDBID()}", showtime.getTitle()) if (showtime.getTMDBID() != None) else showtime.getTitle()) + " " * (title_width - len(showtime.getTitle())) + colors.RESET
     if theaters.getTheater(showtime.getTheaterId()) is not None:
         theater_name = theaters.getTheater(showtime.getTheaterId()).getName()
     else:
@@ -18,7 +27,10 @@ def println(found_in_watchlist: bool, counter: int, showtime: Show, title_width:
     date = str(showtime.getStartDate()).ljust(date_width)
     calendar = href(showtime.createGoogleCalendarEvent(theaters), f"{colors.DARK_GRAY}📅{colors.RESET}")
     not_found = f"{colors.DARK_GRAY}?{colors.RESET}" if showtime.getTMDBID() is None else ""
-    print(line + counter_string + title + theater + date + calendar +not_found)
+    if minimal:
+        print(title + theater + date)
+    else:
+        print(line + counter_string + title + theater + date + calendar +not_found)
     return True
 
 def getWidths(showtimes, theaters):
@@ -32,21 +44,30 @@ def getWidths(showtimes, theaters):
         max_date_width = max(max_date_width, len(str(showtime.getStartDate())))
     return max_title_width, max_theater_width, max_date_width
 
-def display_showtimes_with_watchlist(showtimes, watchlist, theaters):
+def display_showtimes_with_account(showtimes, watchlist, theaters, seen_movies, limit: int, ignore: bool, minimal: bool):
     counter = 1
     max_title_width, max_theater_width, max_date_width = getWidths(showtimes, theaters)
     for showtime in showtimes.getShowtimes():
+        if limit is not None and counter >= limit:
+            break
         found_in_watchlist = False
+        found_in_seen_movies = False
         for movie in watchlist.getWatchList():
             if movie.getTMDBID() is not None and showtime.getTMDBID() is not None:
                 if int(showtime.getTMDBID()) == int(movie.getTMDBID()):
                     found_in_watchlist = True
-        if println(found_in_watchlist, counter, showtime, max_title_width + 7, max_theater_width + 7, max_date_width, len(showtimes.getShowtimes()), theaters):
+        for movie in seen_movies.getSeenMovies():
+            if movie.getTMDBID() is not None and showtime.getTMDBID() is not None:
+                if int(showtime.getTMDBID()) == int(movie.getTMDBID()):
+                    found_in_seen_movies = True
+        if not (found_in_seen_movies and ignore) and println(found_in_watchlist, found_in_seen_movies, counter, showtime, max_title_width + 7, max_theater_width + 7, max_date_width, len(showtimes.getShowtimes()), theaters, minimal):
             counter += 1
 
-def display_showtimes(showtimes, theaters):
+def display_showtimes(showtimes, theaters, limit: int, minimal: bool):
     counter = 1
     max_title_width, max_theater_width, max_date_width = getWidths(showtimes, theaters)
     for showtime in showtimes.getShowtimes():
-        if println(False, counter, showtime, max_title_width + 7, max_theater_width + 7, max_date_width, len(showtimes.getShowtimes()), theaters):
+        if limit is not None and counter >= limit:
+            break
+        if println(False, False, counter, showtime, max_title_width + 7, max_theater_width + 7, max_date_width, len(showtimes.getShowtimes()), theaters, minimal):
             counter += 1


### PR DESCRIPTION
The code changes include:
- Added the `-i` or `--ignore` option to the `cine.py` script to ignore movies that the user has already seen in the showtimes.
- Updated the `Theaters` class to accept a `minimal` parameter to control whether to print the "Fetching theaters" message.
- Updated the `Showtimes` class to accept a `minimal` parameter to control whether to print the "Fetching showtimes" message.
- Updated the `WatchList` class to accept a `minimal` parameter to control whether to display the progress bar when fetching the watchlist.feat: Add support for ignoring movies already seen in showtimes